### PR TITLE
Use hierarchy:true queries with scopes

### DIFF
--- a/lib/hooksUniversal.js
+++ b/lib/hooksUniversal.js
@@ -96,7 +96,8 @@ function checkHierarchy(options, model) {
 		// if hierarchy set, check is legal
 		if (include.hierarchy) {
 			if (!includeModel.hierarchy) throw new Sequelize.SequelizeHierarchyError("You cannot get hierarchy of '" + includeModel.name + "' - it is not hierarchical");
-			if (includeModel !== model) throw new Sequelize.SequelizeHierarchyError("You cannot get a hierarchy of '" + includeModel.name + "' without including it from a parent");
+			//Use model names instead of model model references, as Model.scope(...) results in a new model object. The check below should not fail for scoped model
+			if (includeModel.name.singular !== model.name.singular) throw new Sequelize.SequelizeHierarchyError("You cannot get a hierarchy of '" + includeModel.name + "' without including it from a parent");
 			if (include.as !== model.hierarchy.descendentsAs) throw new Sequelize.SequelizeHierarchyError("You cannot set hierarchy on '" + model.name + "' without using the '" + model.hierarchy.descendentsAs + "' accessor");
 			hierarchyExists = true;
 		}


### PR DESCRIPTION
PR for https://github.com/overlookmotel/sequelize-hierarchy/issues/15
Several notes on the code: 

* as folder belongs to drive I skipped making a new model to relate to folder and used drive instead. To be able to test it I needed folders to be created in the scope of drive, so the creation is changed from
```javascript
this.folder.create(...)
```
to 
```javascript
this.aDrive.createFolder(...)
```
* find tests were repeated with scope turned on
* scoped model find with scoped includes were tested. In order to affect included models you must set their model to the scoped one:
```javascript
model.find({
   include: [{
      model: model.scope('something'),
      as: 'something'
   }]
});
```

Note: I have tested the changes against postgres only!