### PR TITLE
Allow throughSchema option

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ These affect the naming of accessors e.g. `instance.getParent()`
 
 * `through`: Name of hierarchy (through) model. Defaults to `'<model name>ancestor'`
 * `throughTable`: Name of hierarchy (through) table. Defaults to `'<model name plural>ancestors'`
-
+* `throughSchema`: Schema of hierarchy (through) table. Defaults to `undefined`, and is optional.
 * `freezeTableName`: When `true`, through table name is same as through model name. Inherits from sequelize define options
 * `camelThrough`: When `true`, through model name and table name are camelized (i.e. `folderAncestor` not `folderancestor`). Inherits from sequelize define options
 

--- a/changelog.md
+++ b/changelog.md
@@ -244,3 +244,8 @@ Breaking changes:
 ## 0.5.7
 
 * README update (for #31)
+
+## 0.5.8
+
+* Added `throughSchema` option
+* README update

--- a/lib/hooksModel.js
+++ b/lib/hooksModel.js
@@ -145,9 +145,10 @@ module.exports = function(Sequelize) {
 						'	WHERE ancestors.*ancestorId = :id' +
 						')';
 
+					sql = utils.replaceTableName(sql, 'through', hierarchy.through, sequelize);
+
 					sql = utils.replaceIdentifiers(sql, {
 						item: model.tableName,
-						through: hierarchy.through.tableName,
 						level: hierarchy.levelFieldName,
 						id: hierarchy.primaryKey,
 						itemId: hierarchy.throughKey,
@@ -200,8 +201,9 @@ module.exports = function(Sequelize) {
 							'	)';
 					}
 
+					sql = utils.replaceTableName(sql, 'through', hierarchy.through, sequelize);
+
 					sql = utils.replaceIdentifiers(sql, {
-						through: hierarchy.through.tableName,
 						itemId: hierarchy.throughKey,
 						ancestorId: hierarchy.throughForeignKey
 					}, sequelize);
@@ -229,8 +231,9 @@ module.exports = function(Sequelize) {
 						'		SELECT :parentId' +
 						'	) AS ancestors';
 
+					sql = utils.replaceTableName(sql, 'through', hierarchy.through, sequelize);
+
 					sql = utils.replaceIdentifiers(sql, {
-						through: hierarchy.through.tableName,
 						itemId: hierarchy.throughKey,
 						ancestorId: hierarchy.throughForeignKey
 					}, sequelize);

--- a/lib/modelExtends.js
+++ b/lib/modelExtends.js
@@ -93,7 +93,7 @@ module.exports = function(Sequelize) {
 				});
 			}
 
-			options.through = sequelize.define(options.through, throughFields, {timestamps: false, paranoid: false, tableName: options.throughTable});
+			options.through = sequelize.define(options.through, throughFields, {timestamps: false, paranoid: false, tableName: options.throughTable, schema: options.throughSchema});
 
 			// create associations through join table
 			this.belongsToMany(this, {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,12 @@ module.exports = {
 		return sql.replace(/[ \t\r\n]+/g, ' ');
 	},
 
+	// replace identifier with model's full table name taking schema into account
+	replaceTableName: function(sql, identifier, model, sequelize) {
+		var throughTableName = model.getTableName();
+		return sql.replace(new RegExp('\\*' + identifier, 'g'), (throughTableName.schema ? throughTableName.toString() : sequelize.queryInterface.quoteIdentifier(throughTableName)));
+	},
+
 	// string format conversion from camelCase or underscored format to human-readable format
 	// e.g. 'fooBar' -> 'Foo Bar', 'foo_bar' -> 'Foo Bar'
 	humanize: function(str) {

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -37,6 +37,20 @@ describe(Support.getTestDialectTeaser('Tests'), function () {
 			expect(folder.hierarchy).to.be.ok;
 		});
 
+		it('allows through options', function() {
+			var folder = this.sequelize.define('folder', {
+				name: Sequelize.STRING
+			});
+
+			folder.isHierarchy({
+				through: 'folderAncestor',
+				throughTable: 'folder_ancestor',
+				throughSchema: 'folder_schema'
+			});
+
+			expect(folder.hierarchy).to.be.ok;
+		});
+
 		it('works via define options', function() {
 			var folder = this.sequelize.define('folder', {
 				name: Sequelize.STRING


### PR DESCRIPTION
- Allow for specifying schema name along with table name for through
table in options object passed to Model.isHierarchy() method.
- Necessary for databases that use schema.