### PR TITLE
Fixed npm tests not working in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "tedious": "^1.13.2",
     "jshint": "^2.9.3",
     "istanbul": "^0.4.5",
-    "coveralls": "^2.11.14"
+    "coveralls": "^2.11.14",
+    "cross-env": "^2.0.1"
   },
   "keywords": [
     "sequelize",
@@ -46,15 +47,15 @@
   "scripts": {
     "test": "npm run jshint && npm run test-main",
     "jshint": "jshint lib test",
-    "test-mysql": "DIALECT=mysql npm run test-main",
-    "test-postgres": "DIALECT=postgres npm run test-main",
-    "test-postgres-native": "DIALECT=postgres-native npm run test-main",
-    "test-sqlite": "DIALECT=sqlite npm run test-main",
-    "test-mssql": "DIALECT=mssql npm run test-main",
-    "test-main": "mocha --check-leaks --colors -t 30000 -R spec 'test/**/*.test.js'",
+    "test-mysql": "cross-env DIALECT=mysql npm run test-main",
+    "test-postgres": "cross-env DIALECT=postgres npm run test-main",
+    "test-postgres-native": "cross-env DIALECT=postgres-native npm run test-main",
+    "test-sqlite": "cross-env DIALECT=sqlite npm run test-main",
+    "test-mssql": "cross-env DIALECT=mssql npm run test-main",
+    "test-main": "mocha --check-leaks --colors -t 30000 -R spec \"test/**/*.test.js\"",
     "cover": "npm run cover-main && rm -rf coverage",
     "coveralls": "npm run cover-main && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
-    "cover-main": "COVERAGE=true istanbul cover _mocha --report lcovonly -- -t 30000 -R spec 'test/**/*.test.js'",
+    "cover-main": "cross-env COVERAGE=true istanbul cover _mocha --report lcovonly -- -t 30000 -R spec \"test/**/*.test.js\"",
     "travis": "if [ $COVERAGE ]; then npm run coveralls; else npm test; fi"
   },
   "engines": {


### PR DESCRIPTION
I've added [cross-env](https://www.npmjs.com/package/cross-env) & swapped single quotes for escaped double quotes so Windows can run all the `npm run test*` scripts.

While working on my previous pull request on Windows, I had to manually add `set ` in front of all the `DIALECT=` environment variables and had to replace `'test/**/*.test.js'` with `test/all.test.js` to let it work. This fixes that problem.

**Edit**: cover, coveralls and cover-main don't work on Windows either, because of the following reasons:
- cover won't work because of the usage of `rm -rf` (this can be fixed by using `rimraf` module)
- coveralls won't work because of the usage of `rm -rf` and `cat` (`rm -rf` can be fixed with `rimraf`. I'm not sure about `cat` though)
- cover-main won't work because of [this issue](https://github.com/gotwarlost/istanbul/issues/90), which can be easily fixed.

Should all of those cover tasks be fixed in this PR as well or is it okay as is? (I suppose the test commands are more important than the cover commands but I'm not sure how you feel about that)