### PR TITLE
Adding levelDifference

### DIFF
--- a/lib/modelExtends.js
+++ b/lib/modelExtends.js
@@ -84,6 +84,7 @@ module.exports = function(Sequelize) {
 
 			// create through table
 			var throughFields = {};
+			throughFields['levelDifference'] = {type: Sequelize.INTEGER, allowNull: true};
 			throughFields[options.throughKey] = {type: this.attributes[options.primaryKey].type, allowNull: false, primaryKey: true};
 			throughFields[options.throughForeignKey] = {type: this.attributes[options.primaryKey].type, allowNull: false, primaryKey: true};
 
@@ -166,11 +167,14 @@ module.exports = function(Sequelize) {
 								var itemId = item[primaryKey];
 								var parentId = item[foreignKey];
 								var parent = parentId !== null ? _.find(parents, {id: parentId}) : {path: []};
+                                                                console.log("PATH:");
+                                                                console.log(parent.path);
 
-								parent.path.forEach(function(ancestorId) {
+								parent.path.forEach(function(ancestorId, idx) {
 									var ancestor = {};
 									ancestor[throughKey] = itemId;
 									ancestor[throughForeignKey] = ancestorId;
+                                                                        ancestor['levelDifference'] =  parent.path.length - idx;
 
 									ancestors.push(ancestor);
 								});


### PR DESCRIPTION
This allows us to do the following query:
root.getDescendents({through:{where:{levelDifference: {lte:2}}}})
So we can control how deep the results are.  I can get the first 2 generations of descendents using this.