### PR TITLE
Fix exception from Sequelize 4.11.0+ when finding underscoredIf

### DIFF
--- a/lib/patches.js
+++ b/lib/patches.js
@@ -15,13 +15,18 @@ module.exports = function(Sequelize) {
     // get Sequelize version
     var sequelizeVersion = Sequelize.version || sequelizeVersionImported;
 
+    // Lodash doesn't seem to be available in Sequelize 4.11.0+ so we get
+    // an exception if we try to use `Sequelize.Utils._.underscoredIf`
+    // directly below since it's an undefined member of undefined var
+    var utilLodash = Sequelize.Utils._ || false;
+
     // define patches
     return semverSelect.object(sequelizeVersion, {
         /*
          * Patches underscoredIf location differing in v2
          */
         underscoredIf: {
-          '^2.0.0': Sequelize.Utils._.underscoredIf,
+          '^2.0.0': utilLodash.underscoredIf,
           '>=3.0.0': Sequelize.Utils.underscoredIf
         },
         /*


### PR DESCRIPTION
With the old code, if Lodash isn't available in utils (which for some
reason is the case in 4.11.0+) the patches.js will throw an exception
since we are trying to find a symbol on an undefined value.

While Lodash _should_ be there, I found [this](https://github.com/sequelize/sequelize/issues/5992) discussion where at least some people want `Sequelize.Util._` gone so this change will ensure that sequelize-hierarchy is decoupled and works in either case.