### PR TITLE
Fix pack - error in modern Sequelize (4.11+) with undescoredIf, and more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ before_script:
   - "export SEQ_PG_USER=postgres"
   - "export SEQ_PG_PW=postgres"
   - 'if [ "$SEQ_VERSION" ]; then npm install sequelize@^$SEQ_VERSION.0.0; fi'
+  - 'if [ "$SEQ_VERSION" == "3" ]; then npm install pg@6; npm install pg-native@1.10.0; fi'
+  - 'if [ "$SEQ_VERSION" == "2" ]; then npm install pg@6; npm install pg-native@1.10.0; fi'
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sequelize-hierarchy.js
 
-(this is fork with few fixes/patches)
+(this is fork with few fixes/patches - see [Changelog](/changelog.md))
 
 # Nested hierarchies for Sequelize
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sequelize-hierarchy.js
 
+(this is fork with few fixes/patches)
+
 # Nested hierarchies for Sequelize
 
 [![NPM version](https://img.shields.io/npm/v/sequelize-hierarchy.svg)](https://www.npmjs.com/package/sequelize-hierarchy)

--- a/changelog.md
+++ b/changelog.md
@@ -361,3 +361,9 @@ Breaking changes:
 * Fix: Tests create `drive` model in correct schema
 * Tests drop all tables after each test
 * Code style in tests
+
+## 1.3.2
+
+* Fix: underscoredIf bug
+* Fix: pg@6 vulnerability (upgrade to pg@7 and fix tests for old sequelize)
+* Fix: searchPath parameter support

--- a/lib/patches.js
+++ b/lib/patches.js
@@ -21,7 +21,7 @@ module.exports = function(Sequelize) {
          * Patches underscoredIf location differing in v2
          */
         underscoredIf: {
-          '^2.0.0': Sequelize.Utils._.underscoredIf,
+          '^2.0.0': Sequelize.Utils._? Sequelize.Utils._.underscoredIf : null,
           '>=3.0.0': Sequelize.Utils.underscoredIf
         },
         /*

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,6 +44,7 @@ var utils = module.exports = {
 	addOptions: function(queryOptions, options) {
 		queryOptions.transaction = options.transaction;
 		queryOptions.logging = options.logging;
+		queryOptions.searchPath = options.searchPath;
 		return queryOptions;
 	},
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-hierarchy",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Nested hierarchies for Sequelize",
   "main": "./lib/",
   "author": {
@@ -22,12 +22,12 @@
     "chai": "^4.1.0",
     "chai-as-promised": "^7.1.1",
     "sequelize": "^4.3.2",
-    "mysql": "~2.10.1",
+    "mysql": "^2.15.0",
     "mysql2": "^1.2.0",
     "sqlite3": "^3.1.4",
-    "pg": "^6.1.0",
+    "pg": "^7.4.0",
     "pg-hstore": "^2.3.2",
-    "pg-native": "^1.10.0",
+    "pg-native": "^2.2.0",
     "tedious": "^1.14.0",
     "jshint": "^2.9.5",
     "istanbul": "^0.4.5",


### PR DESCRIPTION
Related to: https://github.com/overlookmotel/sequelize-hierarchy/issues/142

This is my version (alternative to https://github.com/overlookmotel/sequelize-hierarchy/pull/140 )

**Upd (dec-2017):** Added several fixes to this PR:

- fix for searchPath (see #144)
- bump pg version to fix vulnerability & fix tests for old version of sequelize

**Upd.2**: My fork (https://github.com/deksden/sequelize-hierarchy) is also updated with all recent fixes and all tests are passing.

To use my patched fork from github directly via npm:

```npm --save install deksden/sequelize-hierarchy```

Switch back to original repository version (after patch willbe applied) - just reinstall package as usual.

