### PR TITLE
Implement a bulk hierarchy creation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Nested hierarchies for Sequelize
 
-[![NPM version](https://img.shields.io/npm/v/sequelize-hierarchy.svg)](https://www.npmjs.com/package/sequelize-hierarchy)
+[![NPM version](https://img.shields.io/npm/v/sequelize-hierarchy-ts.svg)](https://www.npmjs.com/package/sequelize-hierarchy)
 [![Build Status](https://img.shields.io/travis/overlookmotel/sequelize-hierarchy/master.svg)](http://travis-ci.org/overlookmotel/sequelize-hierarchy)
 [![Dependency Status](https://img.shields.io/david/overlookmotel/sequelize-hierarchy.svg)](https://david-dm.org/overlookmotel/sequelize-hierarchy)
 [![Dev dependency Status](https://img.shields.io/david/dev/overlookmotel/sequelize-hierarchy.svg)](https://david-dm.org/overlookmotel/sequelize-hierarchy)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Requires Sequelize v2.x.x, v3.x.x, v4.x.x or v5.x.x. Supports only Node v8 or hi
 To load module:
 
 ```js
-const Sequelize = require('sequelize-hierarchy')();
+const Sequelize = require('sequelize-hierarchy-ts')();
 // NB Sequelize must also be present in `node_modules`
 ```
 
@@ -46,7 +46,7 @@ or, a more verbose form useful if chaining multiple Sequelize plugins:
 
 ```js
 const Sequelize = require('sequelize');
-require('sequelize-hierarchy')(Sequelize);
+require('sequelize-hierarchy-ts')(Sequelize);
 ```
 
 ### Initializing hierarchy

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Nested hierarchies for Sequelize
 
-[![NPM version](https://img.shields.io/npm/v/sequelize-hierarchy.svg)](https://www.npmjs.com/package/sequelize-hierarchy)
+[![NPM version](https://img.shields.io/npm/v/sequelize-hierarchy-ts.svg)](https://www.npmjs.com/package/sequelize-hierarchy-ts)
 [![Build Status](https://img.shields.io/travis/overlookmotel/sequelize-hierarchy/master.svg)](http://travis-ci.org/overlookmotel/sequelize-hierarchy)
 [![Dependency Status](https://img.shields.io/david/overlookmotel/sequelize-hierarchy.svg)](https://david-dm.org/overlookmotel/sequelize-hierarchy)
 [![Dev dependency Status](https://img.shields.io/david/dev/overlookmotel/sequelize-hierarchy.svg)](https://david-dm.org/overlookmotel/sequelize-hierarchy)

--- a/lib/hooksModel.js
+++ b/lib/hooksModel.js
@@ -8,7 +8,8 @@
 // Imports
 const {
 	valueFilteredByFields, addOptions, addToFields, inFields,
-	removeSpacing, replaceTableNames, replaceFieldNames, makeCo
+	removeSpacing, replaceTableNames, replaceFieldNames, makeCo,
+	flatten
 } = require('./utils');
 
 // Constants
@@ -27,6 +28,7 @@ module.exports = (Sequelize, patches) => {
 		afterCreate,
 		beforeUpdate,
 		beforeBulkCreate,
+		afterBulkCreate,
 		beforeBulkUpdate
 	});
 
@@ -277,9 +279,89 @@ module.exports = (Sequelize, patches) => {
 		}
 	}
 
-	function beforeBulkCreate(daos, options) {
+	function* beforeBulkCreate(daos, options) {
+		const model = this, // eslint-disable-line no-invalid-this
+			{primaryKey, foreignKey, levelFieldName} = model.hierarchy;
 		// Set individualHooks = true so that beforeCreate and afterCreate hooks run
-		options.individualHooks = true;
+		// options.individualHooks = true;
+
+		const parentIds = daos.map(item => valueFilteredByFields(foreignKey, item, options));
+
+		const parents = yield findAll(
+			model,
+			addOptions({where: {[primaryKey]: parentIds}, attributes: [levelFieldName]}, options)
+		);
+
+		parentIds.forEach((parentId) => {
+			const parent = parents.find(p => p.id === parentId);
+			if (!parent) {
+				throw new HierarchyError('Parent does not exist');
+			}
+		});
+
+		daos.forEach((item) => {
+			const values = item.dataValues;
+			const parentId = valueFilteredByFields(foreignKey, item, options);
+			const parent = parents.find(p => p.id === parentId);
+			// Set hierarchy level
+			values[levelFieldName] = parent[levelFieldName] + 1;
+			addToFields(levelFieldName, options);
+		});
+	}
+
+	function* afterBulkCreate(items, options) {
+		const model = this, // eslint-disable-line no-invalid-this
+			{
+				primaryKey, foreignKey, levelFieldName, through, throughKey, throughForeignKey
+			} = model.hierarchy;
+
+		const itemsWithParentId = items.filter(item => valueFilteredByFields(foreignKey, item, options));
+
+		const parentIds = itemsWithParentId
+			.map(item => valueFilteredByFields(foreignKey, item, options));
+
+
+		const allAncestors = yield findAll(
+			through,
+			addOptions(
+				{
+					where: {[throughKey]: parentIds},
+					attributes: [throughForeignKey, throughKey]
+				},
+				options,
+			)
+		);
+
+		const nestedAncestorsToAdd = itemsWithParentId.map((item) => {
+			const values = item.dataValues;
+			const parentId = valueFilteredByFields(foreignKey, item, options);
+
+			// Get ancestors
+			let ancestors;
+			if (values[levelFieldName] === 2) {
+				// If parent is at top level - no ancestors
+				ancestors = [];
+			} else {
+				// Get parent's ancestors
+				ancestors = allAncestors.filter(a => a[throughKey] === parentId);
+			}
+			// Create row in hierarchy table for parent
+			const itemId = values[primaryKey];
+
+			// Add parent as ancestor
+			const allAncestorIds = ancestors.map(a => a[throughForeignKey]);
+			allAncestorIds.push(allAncestorIds);
+
+			// Save ancestors
+			return allAncestorIds.map(ancestorId => ({
+				[throughForeignKey]: ancestorId,
+				[throughKey]: itemId
+			}));
+		});
+
+		const flatAncestorsToAdd = flatten(nestedAncestorsToAdd);
+
+		yield through.bulkCreate(flatAncestorsToAdd, addOptions({}, options));
 	}
 
 	function* beforeBulkUpdate(options) {

--- a/lib/hooksModel.js
+++ b/lib/hooksModel.js
@@ -311,9 +311,14 @@ module.exports = (Sequelize, patches) => {
 			const values = item.dataValues;
 			const parentId = valueFilteredByFields(foreignKey, item, options);
 			const parent = parents.find(p => p[primaryKey] === parentId);
-			// Set hierarchy level
-			values[levelFieldName] = parent[levelFieldName] + 1;
-			addToFields(levelFieldName, options);
+
+			if (parent) {
+				// Set hierarchy level
+				values[levelFieldName] = parent[levelFieldName] + 1;
+				addToFields(levelFieldName, options);
+			} else {
+				values[levelFieldName] = 1;
+			}
 		});
 	}
 

--- a/lib/hooksModel.js
+++ b/lib/hooksModel.js
@@ -279,30 +279,38 @@ module.exports = (Sequelize, patches) => {
 		}
 	}
 
-	function* beforeBulkCreate(daos, options) {
+	function* beforeBulkCreate(items, options) {
 		const model = this, // eslint-disable-line no-invalid-this
 			{primaryKey, foreignKey, levelFieldName} = model.hierarchy;
 		// Set individualHooks = true so that beforeCreate and afterCreate hooks run
 		// options.individualHooks = true;
 
-		const parentIds = daos.map(item => valueFilteredByFields(foreignKey, item, options));
+		const parentIds = items
+			.map(item => valueFilteredByFields(foreignKey, item, options))
+			.filter(Boolean);
 
 		const parents = yield findAll(
 			model,
-			addOptions({where: {[primaryKey]: parentIds}, attributes: [levelFieldName]}, options)
+			addOptions(
+				{
+					where: {[primaryKey]: parentIds},
+					attributes: [primaryKey, levelFieldName]
+				},
+				options,
+			)
 		);
 
 		parentIds.forEach((parentId) => {
-			const parent = parents.find(p => p.id === parentId);
+			const parent = parents.find(p => p[primaryKey] === parentId);
 			if (!parent) {
 				throw new HierarchyError('Parent does not exist');
 			}
 		});
 
-		daos.forEach((item) => {
+		items.forEach((item) => {
 			const values = item.dataValues;
 			const parentId = valueFilteredByFields(foreignKey, item, options);
-			const parent = parents.find(p => p.id === parentId);
+			const parent = parents.find(p => p[primaryKey] === parentId);
 			// Set hierarchy level
 			values[levelFieldName] = parent[levelFieldName] + 1;
 			addToFields(levelFieldName, options);
@@ -318,8 +326,8 @@ module.exports = (Sequelize, patches) => {
 		const itemsWithParentId = items.filter(item => valueFilteredByFields(foreignKey, item, options));
 
 		const parentIds = itemsWithParentId
-			.map(item => valueFilteredByFields(foreignKey, item, options));
-
+			.map(item => valueFilteredByFields(foreignKey, item, options))
+			.filter(Boolean);
 
 		const allAncestors = yield findAll(
 			through,

--- a/lib/hooksModel.js
+++ b/lib/hooksModel.js
@@ -33,7 +33,6 @@ module.exports = (Sequelize, patches) => {
 	});
 
 	function* beforeCreate(item, options) {
-		console.log('beforeCreate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{primaryKey, foreignKey, levelFieldName} = model.hierarchy,
 			values = item.dataValues,
@@ -62,7 +61,6 @@ module.exports = (Sequelize, patches) => {
 	}
 
 	function* afterCreate(item, options) {
-		console.log('afterCreate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{
 				primaryKey, foreignKey, levelFieldName, through, throughKey, throughForeignKey
@@ -102,7 +100,6 @@ module.exports = (Sequelize, patches) => {
 	}
 
 	function* _beforeUpdate(item, options) {
-		console.log('_beforeUpdate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{sequelize} = model,
 			{
@@ -283,7 +280,6 @@ module.exports = (Sequelize, patches) => {
 	}
 
 	function* beforeBulkCreate(items, options) {
-		console.log('beforeBulkCreate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{primaryKey, foreignKey, levelFieldName} = model.hierarchy;
 		// Set individualHooks = true so that beforeCreate and afterCreate hooks run
@@ -324,11 +320,9 @@ module.exports = (Sequelize, patches) => {
 				values[levelFieldName] = 1;
 			}
 		});
-		console.log('beforeBulkCreate end');
 	}
 
 	function* afterBulkCreate(items, options) {
-		console.log('afterBulkCreate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{
 				primaryKey, foreignKey, levelFieldName, through, throughKey, throughForeignKey
@@ -344,8 +338,6 @@ module.exports = (Sequelize, patches) => {
 			.map(item => valueFilteredByFields(foreignKey, item, options))
 			.filter(Boolean);
 
-		console.log('parentIds', JSON.stringify(parentIds));
-
 		const allAncestors = yield findAll(
 			through,
 			addOptions(
@@ -356,7 +348,6 @@ module.exports = (Sequelize, patches) => {
 				options,
 			)
 		);
-		console.log('allAncestors', JSON.stringify(allAncestors));
 
 		const nestedAncestorsToAdd = itemsWithParentId.map((item) => {
 			const values = item.dataValues;
@@ -378,27 +369,19 @@ module.exports = (Sequelize, patches) => {
 			const inheritedParentIds = ancestors.map(a => a[throughForeignKey]);
 			inheritedParentIds.push(parentId);
 
-			console.log('itemId', JSON.stringify(itemId));
-			console.log('ancestors', JSON.stringify(ancestors));
-			console.log('allAncestorIds', JSON.stringify(inheritedParentIds));
-
 			// Save ancestors
 			return inheritedParentIds.map(ancestorId => ({
 				[throughForeignKey]: ancestorId,
 				[throughKey]: itemId
 			}));
 		});
-		console.log('nestedAncestorsToAdd', JSON.stringify(nestedAncestorsToAdd));
 
 		const flatAncestorsToAdd = flatten(nestedAncestorsToAdd);
-		console.log('flatAncestorsToAdd', JSON.stringify(flatAncestorsToAdd));
 
 		yield through.bulkCreate(flatAncestorsToAdd, addOptions({}, options));
-		console.log('afterBulkCreate end');
 	}
 
 	function* beforeBulkUpdate(options) {
-		console.log('beforeBulkUpdate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{primaryKey, foreignKey, levelFieldName} = model.hierarchy;
 

--- a/lib/hooksModel.js
+++ b/lib/hooksModel.js
@@ -344,6 +344,8 @@ module.exports = (Sequelize, patches) => {
 			.map(item => valueFilteredByFields(foreignKey, item, options))
 			.filter(Boolean);
 
+		console.log('parentIds', JSON.stringify(parentIds));
+
 		const allAncestors = yield findAll(
 			through,
 			addOptions(
@@ -354,6 +356,7 @@ module.exports = (Sequelize, patches) => {
 				options,
 			)
 		);
+		console.log('allAncestors', JSON.stringify(allAncestors));
 
 		const nestedAncestorsToAdd = itemsWithParentId.map((item) => {
 			const values = item.dataValues;
@@ -375,14 +378,20 @@ module.exports = (Sequelize, patches) => {
 			const allAncestorIds = ancestors.map(a => a[throughForeignKey]);
 			allAncestorIds.push(allAncestorIds);
 
+			console.log('itemId', JSON.stringify(itemId));
+			console.log('ancestors', JSON.stringify(ancestors));
+			console.log('allAncestorIds', JSON.stringify(allAncestorIds));
+
 			// Save ancestors
 			return allAncestorIds.map(ancestorId => ({
 				[throughForeignKey]: ancestorId,
 				[throughKey]: itemId
 			}));
 		});
+		console.log('nestedAncestorsToAdd', JSON.stringify(nestedAncestorsToAdd));
 
 		const flatAncestorsToAdd = flatten(nestedAncestorsToAdd);
+		console.log('flatAncestorsToAdd', JSON.stringify(flatAncestorsToAdd));
 
 		yield through.bulkCreate(flatAncestorsToAdd, addOptions({}, options));
 		console.log('afterBulkCreate end');

--- a/lib/hooksModel.js
+++ b/lib/hooksModel.js
@@ -375,15 +375,15 @@ module.exports = (Sequelize, patches) => {
 			const itemId = values[primaryKey];
 
 			// Add parent as ancestor
-			const allAncestorIds = ancestors.map(a => a[throughForeignKey]);
-			allAncestorIds.push(allAncestorIds);
+			const inheritedParentIds = ancestors.map(a => a[throughForeignKey]);
+			inheritedParentIds.push(parentId);
 
 			console.log('itemId', JSON.stringify(itemId));
 			console.log('ancestors', JSON.stringify(ancestors));
-			console.log('allAncestorIds', JSON.stringify(allAncestorIds));
+			console.log('allAncestorIds', JSON.stringify(inheritedParentIds));
 
 			// Save ancestors
-			return allAncestorIds.map(ancestorId => ({
+			return inheritedParentIds.map(ancestorId => ({
 				[throughForeignKey]: ancestorId,
 				[throughKey]: itemId
 			}));

--- a/lib/hooksModel.js
+++ b/lib/hooksModel.js
@@ -33,6 +33,7 @@ module.exports = (Sequelize, patches) => {
 	});
 
 	function* beforeCreate(item, options) {
+		console.log('beforeCreate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{primaryKey, foreignKey, levelFieldName} = model.hierarchy,
 			values = item.dataValues,
@@ -61,6 +62,7 @@ module.exports = (Sequelize, patches) => {
 	}
 
 	function* afterCreate(item, options) {
+		console.log('afterCreate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{
 				primaryKey, foreignKey, levelFieldName, through, throughKey, throughForeignKey
@@ -100,6 +102,7 @@ module.exports = (Sequelize, patches) => {
 	}
 
 	function* _beforeUpdate(item, options) {
+		console.log('_beforeUpdate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{sequelize} = model,
 			{
@@ -280,6 +283,7 @@ module.exports = (Sequelize, patches) => {
 	}
 
 	function* beforeBulkCreate(items, options) {
+		console.log('beforeBulkCreate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{primaryKey, foreignKey, levelFieldName} = model.hierarchy;
 		// Set individualHooks = true so that beforeCreate and afterCreate hooks run
@@ -315,20 +319,26 @@ module.exports = (Sequelize, patches) => {
 			if (parent) {
 				// Set hierarchy level
 				values[levelFieldName] = parent[levelFieldName] + 1;
-				addToFields(levelFieldName, options);
+				// addToFields(levelFieldName, options);
 			} else {
 				values[levelFieldName] = 1;
 			}
 		});
+		console.log('beforeBulkCreate end');
 	}
 
 	function* afterBulkCreate(items, options) {
+		console.log('afterBulkCreate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{
 				primaryKey, foreignKey, levelFieldName, through, throughKey, throughForeignKey
 			} = model.hierarchy;
 
 		const itemsWithParentId = items.filter(item => valueFilteredByFields(foreignKey, item, options));
+
+		if (!itemsWithParentId) {
+			return;
+		}
 
 		const parentIds = itemsWithParentId
 			.map(item => valueFilteredByFields(foreignKey, item, options))
@@ -375,9 +385,11 @@ module.exports = (Sequelize, patches) => {
 		const flatAncestorsToAdd = flatten(nestedAncestorsToAdd);
 
 		yield through.bulkCreate(flatAncestorsToAdd, addOptions({}, options));
+		console.log('afterBulkCreate end');
 	}
 
 	function* beforeBulkUpdate(options) {
+		console.log('beforeBulkUpdate start');
 		const model = this, // eslint-disable-line no-invalid-this
 			{primaryKey, foreignKey, levelFieldName} = model.hierarchy;
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,69 @@
+/* eslint-ignore */
+
+import {
+	FindOptions,
+	HasManyAddAssociationMixin,
+	HasManyGetAssociationsMixin,
+	HasManyRemoveAssociationMixin,
+	Model,
+} from 'sequelize';
+
+interface HierarchyFindOptions extends FindOptions {
+	hierarchy?: boolean;
+}
+
+interface IsHierarchyOptions {
+	// as: Name of parent association. Defaults to 'parent'.
+	as?: string;
+	// childrenAs: Name of children association. Defaults to 'children'.
+	childrenAs?: string;
+	// ancestorsAs: Name of ancestors association. Defaults to 'ancestors'.
+	ancestorsAs?: string;
+	// descendentsAs: Name of descendents association. Defaults to 'descendents'.
+	descendentsAs?: string;
+	// primaryKey: Name of the primary key. Defaults to model's primaryKeyAttribute.
+	primaryKey?: string;
+	// foreignKey: Name of the parent field. Defaults to 'parentId'.
+	foreignKey?: string;
+	// levelFieldName: Name of the hierarchy depth field. Defaults to 'hierarchyLevel'.
+	levelFieldName?: string;
+	// freezeTableName: When true, through table name is same as through model name.
+	// Inherits from sequelize define options.
+	freezeTableName?: boolean;
+	// throughSchema: Schema of hierarchy (through) table. Defaults to model.options.schema, and is optional.
+	throughSchema?: string;
+	// through: Name of hierarchy (through) model. Defaults to '<model name>ancestor'.
+	through?: string;
+	// throughTable: Name of hierarchy (through) table. Defaults to '<model name plural>ancestors'.
+	throughTable?: string;
+	// throughKey: Name of the instance field in hierarchy (through) table. Defaults to '<model name>Id'.
+	throughKey?: string;
+	// throughForeignKey: Name of the ancestor field in hierarchy (through) table. Defaults to 'ancestorId'.
+	throughForeignKey?: string;
+	// camelThrough: When true, through model name and table name are camelized (i.e. folderAncestor not folderancestor).
+	// Inherits from sequelize define options.
+	camelThrough?: boolean;
+	// labels: When true, creates an attribute label on the created parentId and hierarchyLevel fields
+	// which is a human-readable version of the field name. Inherits from sequelize define options or false.
+	labels?: boolean;
+}
+
+export class HierarchyModel<T extends Model, PrimaryKeyType = string> extends Model {
+	/* Only available when in the query `hierarchy` is `true` */
+	public children?: T[];
+	public descendants?: T[];
+
+	public addChild!: HasManyAddAssociationMixin<T, PrimaryKeyType>;
+	public removeChild!: HasManyRemoveAssociationMixin<T, PrimaryKeyType>
+	public getChildren!: HasManyGetAssociationsMixin<T>;
+	public getParent!: HasManyGetAssociationsMixin<T>;
+
+	// @ts-ignore implemented by JS code
+	public static isHierarchy<T>(options: IsHierarchyOptions): T;
+
+	// @ts-ignore implemented by JS code
+	public static findAll<T extends Model>(
+		this: { new (): T } & typeof Model,
+		options?: HierarchyFindOptions
+	): Promise<T[]>;
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,7 +20,8 @@ module.exports = {
 	inFields,
 	valueFilteredByFields,
 	addToFields,
-	makeCo
+	makeCo,
+	flatten
 };
 
 // Remove spacing from SQL
@@ -110,4 +111,11 @@ function makeCo(Sequelize) {
 	}
 
 	return {co, coAll};
+}
+
+// source - https://stackoverflow.com/a/15030117/3178311
+function flatten(arr) {
+	return arr
+		.reduce((flat, toFlatten) => flat
+			.concat(Array.isArray(toFlatten) ? flatten(toFlatten) : toFlatten), []);
 }

--- a/package.json
+++ b/package.json
@@ -1,17 +1,15 @@
 {
-  "name": "sequelize-hierarchy",
-  "version": "2.0.4",
+  "name": "sequelize-hierarchy-ts",
+  "version": "2.0.5",
   "description": "Nested hierarchies for Sequelize",
   "main": "index.js",
-  "author": {
-    "name": "Overlook Motel"
-  },
+  "author": "Fizure",
   "repository": {
     "type": "git",
-    "url": "https://github.com/overlookmotel/sequelize-hierarchy.git"
+    "url": "git+https://github.com/fizure/sequelize-hierarchy.git"
   },
   "bugs": {
-    "url": "https://github.com/overlookmotel/sequelize-hierarchy/issues"
+    "url": "https://github.com/fizure/sequelize-hierarchy/issues"
   },
   "dependencies": {
     "is-generator": "^1.0.3",
@@ -65,6 +63,10 @@
   "engines": {
     "node": ">=8"
   },
-  "readmeFilename": "README.md",
-  "license": "MIT"
+  "license": "MIT",
+  "homepage": "https://github.com/fizure/sequelize-hierarchy#readme",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize-hierarchy-ts",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Nested hierarchies for Sequelize",
   "main": "index.js",
   "author": "Fizure",


### PR DESCRIPTION
I used this library in a project and it seemed as if the one-by-one creation was wayyyy too slow. This implements bulk insertion of items + also bulk insertion of the hierarchy connections later.

What this code atm still assumes (I have the logic outside of the scope of this library implemented tho) is that the nodes are bulk inserted layer by layer so that the parent nodes already exist when the children are created. Since I don't want to define the on my own in the initially created DTO and want to have it detected by the library, I don't need it for my use-case.